### PR TITLE
cbzip2: handle writes, flushes and closes properly

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -3,10 +3,39 @@ package cbzip2
 import "errors"
 
 var (
-	ErrBadParam       = errors.New("bad param (should be impossible)")
-	ErrBadData        = errors.New("integrity problem detected in input data")
-	ErrBadMagic       = errors.New("compressed stream does not being with magic bytes")
-	ErrMem            = errors.New("insufficient memory available ಠ_ಠ")
-	ErrInit           = errors.New("unable to initialize bzlib.h")
-	ErrBadCompression = errors.New("unable to compress data")
+	ErrBadParam = errors.New("bad parameters given to bzip")
+	ErrBadData  = errors.New("integrity problem detected in input data")
+	ErrBadMagic = errors.New("compressed stream does not being with magic bytes")
+	ErrMem      = errors.New("insufficient memory available ಠ_ಠ")
+	ErrSequence = errors.New("bzip2 sequence error")
+	ErrIo       = errors.New("i/o error")
+	ErrEOF      = errors.New("unexpected EOF")
+	ErrOutFull  = errors.New("output buffer full")
+	ErrConfig   = errors.New("config error")
+	ErrUnknown  = errors.New("unknown error")
 )
+
+func retCodeToErr(ret int) error {
+	switch ret {
+	case BZ_SEQUENCE_ERROR:
+		return ErrSequence
+	case BZ_PARAM_ERROR:
+		return ErrBadParam
+	case BZ_MEM_ERROR:
+		return ErrMem
+	case BZ_DATA_ERROR:
+		return ErrBadData
+	case BZ_DATA_ERROR_MAGIC:
+		return ErrBadMagic
+	case BZ_IO_ERROR:
+		return ErrIo
+	case BZ_UNEXPECTED_EOF:
+		return ErrEOF
+	case BZ_OUTBUFF_FULL:
+		return ErrOutFull
+	case BZ_CONFIG_ERROR:
+		return ErrConfig
+	default:
+		return ErrUnknown
+	}
+}

--- a/writer.go
+++ b/writer.go
@@ -30,7 +30,7 @@ func NewWriter(w io.Writer) (*Writer, error) {
 	wrtr.bz = &C.bz_stream{bzalloc: nil, bzfree: nil, opaque: nil}
 
 	if result := C.BZ2_bzCompressInit(wrtr.bz, blockSize, verbosity, workFactor); result != BZ_OK {
-		return nil, ErrInit
+		return nil, retCodeToErr(int(result))
 	}
 
 	return wrtr, nil
@@ -42,33 +42,6 @@ func (b *Writer) Write(d []byte) (int, error) {
 	if b.err != nil {
 		return 0, b.err
 	}
-	return b.write(d, BZ_RUN)
-}
-
-// Flush writes any pending data to the underlying writer.
-func (b *Writer) Flush() error {
-	if b.err != nil {
-		return b.err
-	}
-	_, err := b.write(nil, BZ_FLUSH)
-	return err
-}
-
-// Close closes the writer, flushing any unwritten data to the underlying io.Writer
-// Close does not close the underlying io.Writer.
-func (b *Writer) Close() error {
-	if b.err != nil {
-		return b.err
-	}
-	if _, err := b.write(nil, BZ_FINISH); err != nil {
-		return err
-	}
-	C.BZ2_bzCompressEnd(b.bz)
-	b.err = io.EOF
-	return nil
-}
-
-func (b *Writer) write(d []byte, flush int) (int, error) {
 	if len(d) == 0 {
 		b.bz.avail_in = 0
 		b.bz.next_in = (*C.char)(unsafe.Pointer(nil))
@@ -77,29 +50,81 @@ func (b *Writer) write(d []byte, flush int) (int, error) {
 		b.bz.next_in = (*C.char)(unsafe.Pointer(&d[0]))
 	}
 
-	// loop until we don't have a full output buffer
-	// this will also write to the underlying writer
+	// loop until there's no more input data
 	for {
-		// give the compressor our output buffer
-		b.bz.next_out = (*C.char)(unsafe.Pointer(&b.out[0]))
-		b.bz.avail_out = (C.uint)(len(b.out))
-		// add data with our specified call to the buffer
-		if ret := C.BZ2_bzCompress(b.bz, (C.int)(flush)); ret < 0 {
-			b.err = ErrBadCompression
+		_, err := b.compress(BZ_RUN)
+		if err != nil {
+			b.err = err
 			return 0, b.err
 		}
-		// we have (total length) - (space available) of data
-		have := len(b.out) - int(b.bz.avail_out)
-		_, b.err = b.w.Write(b.out[:have])
-		if b.err != nil {
-			C.BZ2_bzCompressEnd(b.bz)
-			return 0, b.err
-		}
-		// we have available output buffer, drop out
-		// and get more data
-		if b.bz.avail_out != 0 {
+		// if we've processed all of the input, break
+		if b.bz.avail_in == 0 {
 			break
 		}
 	}
 	return len(d), nil
+}
+
+// Flush writes any pending data to the underlying writer.
+func (b *Writer) Flush() error {
+	if b.err != nil {
+		return b.err
+	}
+	for {
+		ret, err := b.compress(BZ_FLUSH)
+		if err != nil {
+			b.err = err
+			return b.err
+		}
+		// if we're done flushing, return
+		if ret == BZ_RUN_OK {
+			break
+		}
+	}
+	return nil
+}
+
+// Close closes the writer, flushing any unwritten data to the underlying io.Writer
+// Close does not close the underlying io.Writer.
+func (b *Writer) Close() error {
+	if b.err != nil {
+		return b.err
+	}
+	for {
+		ret, err := b.compress(BZ_FINISH)
+		if err != nil {
+			b.err = err
+			return b.err
+		}
+		// When we get to the actual end of the stream, break
+		if ret == BZ_STREAM_END {
+			break
+		}
+	}
+
+	C.BZ2_bzCompressEnd(b.bz)
+	b.err = io.EOF
+	return nil
+}
+
+func (b *Writer) compress(flush int) (int, error) {
+	// give the compressor our output buffer
+	b.bz.next_out = (*C.char)(unsafe.Pointer(&b.out[0]))
+	b.bz.avail_out = (C.uint)(len(b.out))
+
+	// add data with our specified call to the buffer
+	ret := C.BZ2_bzCompress(b.bz, (C.int)(flush))
+	if ret < 0 {
+		return 0, retCodeToErr(int(ret))
+	}
+
+	// we have (total length) - (space available) of data
+	have := len(b.out) - int(b.bz.avail_out)
+	_, err := b.w.Write(b.out[:have])
+	if err != nil {
+		C.BZ2_bzCompressEnd(b.bz)
+		return 0, err
+	}
+
+	return int(ret), nil
 }

--- a/writer_test.go
+++ b/writer_test.go
@@ -32,7 +32,9 @@ func TestBasicCompress(t *testing.T) {
 		if err != nil {
 			t.Fatalf("error writing data: %s", err)
 		}
-		wrtr.Close()
+		if err := wrtr.Close(); err != nil {
+			t.Fatalf("failed to close bzip2 writer: %s", err)
+		}
 		if !reflect.DeepEqual(b.Bytes(), v.want) {
 			t.Logf("got: %#v", b.Bytes())
 			t.Logf("want: %#v", v.want)
@@ -60,7 +62,9 @@ func TestRandomCompress(t *testing.T) {
 	if err != nil {
 		t.Fatalf("error compressing data: %s", err)
 	}
-	wrtr.Close()
+	if err := wrtr.Close(); err != nil {
+		t.Fatalf("failed to close bzip2 writer: %s", err)
+	}
 	// use the built in bzip2 to read the data back out
 	var decompress bytes.Buffer
 	bzipOut := bzip2.NewReader(&out)


### PR DESCRIPTION
Fixes #4 - previously I was trying to be smart with how we determined we were done writing, but that didn't work.

Now we've split the Write, Flush and Close to handle their own data with return codes properly.

@macb @aybabtme and @jphines